### PR TITLE
rework CMake workflow of lib:

### DIFF
--- a/src/OpenCOVER/plugins/hlrs/Energy/CMakeLists.txt
+++ b/src/OpenCOVER/plugins/hlrs/Energy/CMakeLists.txt
@@ -49,7 +49,14 @@ SET(SOURCES
 
 set(Name "EnergyCampus")
 add_subdirectory(lib)
-cover_add_plugin(${Name} nlohmann_json::nlohmann_json Arrow::arrow_shared EnergyLib coCurlHTTPClient coThreadUtil coStringUtil coReadCSVUtil ${HEADERS} ${SOURCES})
+cover_add_plugin(
+    ${Name} 
+    ApacheArrow 
+    Ennovatis 
+    EnergyCore
+    ${HEADERS} ${SOURCES})
+
+
 target_include_directories(${Name} PRIVATE
 	"${CMAKE_CURRENT_BINARY_DIR}/lib/ennovatis/include")
 set_target_properties(${Name} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)

--- a/src/OpenCOVER/plugins/hlrs/Energy/lib/CMakeLists.txt
+++ b/src/OpenCOVER/plugins/hlrs/Energy/lib/CMakeLists.txt
@@ -1,8 +1,3 @@
 add_subdirectory(core)
 add_subdirectory(ennovatis)
 add_subdirectory(apache)
-
-set(Name "EnergyLib")
-add_library(${Name} STATIC $<TARGET_OBJECTS:EnergyCore> $<TARGET_OBJECTS:Ennovatis> $<TARGET_OBJECTS:Apache_Arrow>)
-target_compile_options(${Name} PRIVATE -fPIC)
-COVISE_INSTALL_TARGET(${Name})

--- a/src/OpenCOVER/plugins/hlrs/Energy/lib/apache/CMakeLists.txt
+++ b/src/OpenCOVER/plugins/hlrs/Energy/lib/apache/CMakeLists.txt
@@ -13,7 +13,9 @@ set(HEADERS
 	enums.h
 )
 
-set(Name "Apache_Arrow")
-add_library(${Name} OBJECT ${SOURCES} ${HEADERS})
+set(Name "ApacheArrow")
+add_library(${Name} STATIC ${SOURCES} ${HEADERS})
 target_link_libraries(${Name} PRIVATE Arrow::arrow_shared)
+target_include_directories(${Name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set_target_properties(${Name} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+COVISE_INSTALL_TARGET(${Name})

--- a/src/OpenCOVER/plugins/hlrs/Energy/lib/core/CMakeLists.txt
+++ b/src/OpenCOVER/plugins/hlrs/Energy/lib/core/CMakeLists.txt
@@ -1,38 +1,8 @@
-USING(OpenSceneGraph)
-set(SOURCES
-    utils/color.cpp
-    utils/osgUtils.cpp
-    utils/math.cpp
-    simulation/heating.cpp
-    simulation/power.cpp
-    simulation/simulation.cpp
-)
-
-set(HEADERS
-    interfaces/IBuilding.h
-    interfaces/IEnergyGrid.h
-    interfaces/IColorable.h
-    interfaces/IDrawable.h
-    interfaces/IDrawables.h
-    interfaces/IInfoboard.h
-    interfaces/IInformable.h
-    interfaces/IMovable.h
-    interfaces/ITimedependable.h
-    interfaces/ISolarPanel.h
-    interfaces/ISystem.h
-    utils/color.h
-    utils/osgUtils.h
-    utils/math.h
-    simulation/heating.h
-    simulation/simulation.h
-    simulation/power.h
-    simulation/object.h
-    constants.h
-)
-
 set(Name "EnergyCore")
-add_library(${Name} OBJECT ${SOURCES} ${HEADERS})
-target_link_libraries(${Name} ${EXTRA_LIBS})
-target_include_directories(${Name} PRIVATE ${OPENSCENEGRAPH_INCLUDE_DIRS})
-set_target_properties(${Name} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
-set_target_properties(${Name} PROPERTIES LINKER_LANGUAGE CXX POSITION_INDEPENDENT_CODE ON)
+add_subdirectory(interfaces)
+add_subdirectory(simulation)
+add_subdirectory(utils)
+
+add_library(${Name} INTERFACE)
+target_link_libraries(${Name} INTERFACE core::interface INTERFACE core::simulation INTERFACE core::utils)
+COVISE_INSTALL_TARGET(${Name})

--- a/src/OpenCOVER/plugins/hlrs/Energy/lib/core/utils/osgUtils.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Energy/lib/core/utils/osgUtils.cpp
@@ -1,7 +1,7 @@
 #include "osgUtils.h"
 
 #include <GL/gl.h>
-#include <utils/color.h>
+#include "color.h"
 
 #include <cassert>
 #include <iostream>

--- a/src/OpenCOVER/plugins/hlrs/Energy/lib/ennovatis/CMakeLists.txt
+++ b/src/OpenCOVER/plugins/hlrs/Energy/lib/ennovatis/CMakeLists.txt
@@ -22,15 +22,18 @@ set(HEADERS
 )
 
 set(Name "Ennovatis")
-add_library(${Name} OBJECT ${SOURCES} ${HEADERS})
+add_library(${Name} STATIC ${SOURCES} ${HEADERS})
 target_compile_options(${Name} PRIVATE -fPIC)
 add_dependencies(${Name} coCurlHTTPClient coThreadUtil)
-target_link_libraries(${Name} 
-	nlohmann_json::nlohmann_json
-	coCurlHTTPClient
-	coThreadUtil
-	coReadCSVUtil)
+target_link_libraries(
+	${Name} 
+	PRIVATE nlohmann_json::nlohmann_json
+	PRIVATE coCurlHTTPClient
+	PRIVATE coThreadUtil
+	PRIVATE coReadCSVUtil)
 
 # Add generated header path to include paths.
 target_include_directories(${Name} PRIVATE
 	"${CMAKE_CURRENT_BINARY_DIR}/include")
+
+COVISE_INSTALL_TARGET(${Name})

--- a/src/OpenCOVER/plugins/hlrs/Energy/test/CMakeLists.txt
+++ b/src/OpenCOVER/plugins/hlrs/Energy/test/CMakeLists.txt
@@ -10,19 +10,50 @@ project(EnergyTest)
 # GoogleTest requires at least C++14
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+<<<<<<< HEAD
 find_package(GTest REQUIRED)
+=======
+
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY "https://github.com/google/googletest.git"
+    GIT_TAG "v1.17.0"
+    GIT_SHALLOW TRUE #copy version and not git history
+
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+>>>>>>> 474ad4a9a (rework CMake workflow of lib:)
 file(GLOB_RECURSE TEST_SOURCES "src/*.cpp")
 
 enable_testing()
 
 add_executable(
     Test ${TEST_SOURCES} 
-    $<TARGET_OBJECTS:Ennovatis>
-    $<TARGET_OBJECTS:Apache_Arrow>)
-target_include_directories(Test PRIVATE
-    ${CMAKE_SOURCE_DIR}/src/OpenCOVER/plugins/hlrs/Energy
 )
-target_link_libraries(Test Arrow::arrow_shared coCurlHTTPClient nlohmann_json::nlohmann_json coThreadUtil coStringUtil coReadCSVUtil GTest::gtest_main)
+
+target_include_directories(Test 
+    PRIVATE ${CMAKE_SOURCE_DIR}/src/OpenCOVER/plugins/hlrs/Energy 
+    PRIVATE ${OPENSCENEGRAPH_INCLUDE_DIRS}
+)
+target_link_libraries(
+    Test 
+    PRIVATE ApacheArrow 
+    PRIVATE Ennovatis 
+    PRIVATE coCurlHTTPClient 
+    PRIVATE coThreadUtil 
+    PRIVATE coStringUtil 
+    PRIVATE coReadCSVUtil 
+    PRIVATE core::simulation 
+    PRIVATE Arrow::arrow_shared 
+    PRIVATE nlohmann_json::nlohmann_json 
+    PRIVATE GTest::gtest_main 
+    ${EXTRA_LIBS}
+)
+
 add_definitions(-DENERGYCAMPUS_TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data")
 
 include(GoogleTest)


### PR DESCRIPTION
- rename Apache_Arrow to ApacheArrow
- removing OBJECT libs and build static libs to integrate better in existing eco system
- seperate EnergyCore into namespaces core::interface, core::simulation and core::utils