### PR TITLE
add missing CMakeLists.txt

### DIFF
--- a/src/OpenCOVER/plugins/hlrs/Energy/lib/core/interfaces/CMakeLists.txt
+++ b/src/OpenCOVER/plugins/hlrs/Energy/lib/core/interfaces/CMakeLists.txt
@@ -1,0 +1,22 @@
+USING(OpenSceneGraph)
+
+set(HEADERS
+    IBuilding.h
+    IEnergyGrid.h
+    IColorable.h
+    IDrawable.h
+    IDrawables.h
+    IInfoboard.h
+    IInformable.h
+    IMovable.h
+    ITimedependable.h
+    ISolarPanel.h
+    ISystem.h
+)
+
+set(Name "interface")
+add_library(${Name} INTERFACE ${HEADERS})
+target_link_libraries(${Name} INTERFACE ${EXTRA_LIBS})
+target_include_directories(${Name} INTERFACE ${OPENSCENEGRAPH_INCLUDE_DIRS})
+add_library(core::interface ALIAS ${Name})
+COVISE_INSTALL_TARGET(${Name})

--- a/src/OpenCOVER/plugins/hlrs/Energy/lib/core/simulation/CMakeLists.txt
+++ b/src/OpenCOVER/plugins/hlrs/Energy/lib/core/simulation/CMakeLists.txt
@@ -1,0 +1,22 @@
+set(SOURCES
+    heating.cpp
+    power.cpp
+    simulation.cpp
+)
+
+set(HEADERS
+    heating.h
+    simulation.h
+    power.h
+    object.h
+    object_factory.h
+    object_type.h
+)
+
+set(Name "simulation")
+add_library(${Name} STATIC ${SOURCES} ${HEADERS})
+add_library(core::simulation ALIAS ${Name})
+target_compile_options(${Name} PRIVATE -fPIC)
+target_include_directories(${Name} PRIVATE
+	"${CMAKE_CURRENT_BINARY_DIR}/include")
+COVISE_INSTALL_TARGET(${Name})

--- a/src/OpenCOVER/plugins/hlrs/Energy/lib/core/utils/CMakeLists.txt
+++ b/src/OpenCOVER/plugins/hlrs/Energy/lib/core/utils/CMakeLists.txt
@@ -1,0 +1,24 @@
+USING(OpenSceneGraph)
+set(SOURCES
+    color.cpp
+    osgUtils.cpp
+    math.cpp
+)
+
+set(HEADERS
+    color.h
+    osgUtils.h
+    math.h
+)
+
+set(Name "utils")
+add_library(${Name} STATIC ${SOURCES} ${HEADERS})
+target_link_libraries(${Name} ${EXTRA_LIBS})
+target_compile_options(${Name} PRIVATE -fPIC)
+target_include_directories(
+    ${Name} 
+    PRIVATE ${OPENSCENEGRAPH_INCLUDE_DIRS}
+	PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/include"
+    )
+add_library(core::utils ALIAS ${Name})
+COVISE_INSTALL_TARGET(${Name})


### PR DESCRIPTION
COVISE ignores CMakeLists.txt in subfolders of plugin. These need to be added manually.